### PR TITLE
Select cpus from os.sched_getaffinity()

### DIFF
--- a/bigslice/bigslice
+++ b/bigslice/bigslice
@@ -8,13 +8,13 @@
 
 import argparse
 from argparse import RawTextHelpFormatter
-from os import getpid, path, makedirs, remove
+from os import getpid, path, makedirs, remove, sched_getaffinity
 from sys import argv
 from tempfile import TemporaryDirectory
 import glob
 import re
 import shutil
-from multiprocessing import Pool, cpu_count
+from multiprocessing import Pool
 import bigslice  # for referencing module folders
 from bigslice.modules.data.database import Database
 from bigslice.modules.data.bgc import BGC
@@ -51,13 +51,16 @@ def get_elapsed():
 
 
 def fetch_pool(num_threads: int):
+    num_cpus = len(sched_getaffinity(0))
+    if num_threads > num_cpus:
+        print("There were more threads ({}) requested than CPUs available ({}), setting num_threads to {}\n".format(num_threads, num_cpus, num_cpus))
+        num_threads = num_cpus
     pool = Pool(processes=num_threads)
-
     try:
         # set cores for the multiprocessing pools
         all_cpu_ids = set()
         for i, p in enumerate(pool._pool):
-            cpu_id = str(cpu_count() - (i % cpu_count()) - 1)
+            cpu_id = str(list(sched_getaffinity(0))[i])
             subprocess.run(["taskset",
                             "-p", "-c",
                             cpu_id,
@@ -72,7 +75,6 @@ def fetch_pool(num_threads: int):
 
     except FileNotFoundError:
         pass  # running in OSX?
-
     return pool
 
 
@@ -817,7 +819,7 @@ def main():
         ))
     arg_group_perf.add_argument(
         "-t", "--num_threads",
-        default=cpu_count(), type=int, metavar="<N>",
+        default=len(sched_getaffinity(0)), type=int, metavar="<N>",
         help=("The number of parallel jobs to run (default: %(default)s)."))
     arg_group_perf.add_argument(
         "--hmmscan_chunk_size",

--- a/bigslice/bigslice
+++ b/bigslice/bigslice
@@ -52,15 +52,13 @@ def get_elapsed():
 
 def fetch_pool(num_threads: int):
     num_cpus = len(sched_getaffinity(0))
-    if num_threads > num_cpus:
-        print("There were more threads ({}) requested than CPUs available ({}), setting num_threads to {}\n".format(num_threads, num_cpus, num_cpus))
-        num_threads = num_cpus
+    available_cpu_ids = list(sched_getaffinity(0))
     pool = Pool(processes=num_threads)
     try:
         # set cores for the multiprocessing pools
         all_cpu_ids = set()
         for i, p in enumerate(pool._pool):
-            cpu_id = str(list(sched_getaffinity(0))[i])
+            cpu_id = str(available_cpu_ids[len(available_cpu_ids) - (i % len(available_cpu_ids)) - 1)]
             subprocess.run(["taskset",
                             "-p", "-c",
                             cpu_id,

--- a/bigslice/bigslice
+++ b/bigslice/bigslice
@@ -57,7 +57,7 @@ def fetch_pool(num_threads: int):
         # set cores for the multiprocessing pools
         all_cpu_ids = set()
         for i, p in enumerate(pool._pool):
-            cpu_id = available_cpu_ids[len(available_cpu_ids) - (i % len(available_cpu_ids)) - 1)]
+            cpu_id = str(available_cpu_ids[len(available_cpu_ids) - (i % len(available_cpu_ids)) - 1])
             subprocess.run(["taskset",
                             "-p", "-c",
                             cpu_id,

--- a/bigslice/bigslice
+++ b/bigslice/bigslice
@@ -57,7 +57,7 @@ def fetch_pool(num_threads: int):
         # set cores for the multiprocessing pools
         all_cpu_ids = set()
         for i, p in enumerate(pool._pool):
-            cpu_id = str(available_cpu_ids[len(available_cpu_ids) - (i % len(available_cpu_ids)) - 1)]
+            cpu_id = available_cpu_ids[len(available_cpu_ids) - (i % len(available_cpu_ids)) - 1)]
             subprocess.run(["taskset",
                             "-p", "-c",
                             cpu_id,

--- a/bigslice/bigslice
+++ b/bigslice/bigslice
@@ -51,7 +51,6 @@ def get_elapsed():
 
 
 def fetch_pool(num_threads: int):
-    num_cpus = len(sched_getaffinity(0))
     available_cpu_ids = list(sched_getaffinity(0))
     pool = Pool(processes=num_threads)
     try:

--- a/bigslice/db/advanced/generate_databases.py
+++ b/bigslice/db/advanced/generate_databases.py
@@ -10,9 +10,8 @@ to do its feature extractions
 """
 
 # python imports
-from os import path, makedirs, remove, rename, SEEK_END
+from os import path, makedirs, remove, rename, SEEK_END, sched_getaffinity
 from shutil import copy, rmtree, copyfileobj
-from multiprocessing import cpu_count
 from hashlib import md5
 import urllib.request
 import gzip
@@ -358,7 +357,7 @@ def main():
             "hmmsearch",
             "--acc",
             "--cut_ga",
-            "--cpu", str(cpu_count()),
+            "--cpu", str(len(sched_getaffinity(0))),
             "-o", ref_prot_hmmtxt,
             core_hmms_path,
             path.join(tmp_dir_path, stored_ref_prot_filename)
@@ -534,7 +533,7 @@ def build_subpfam(input_fasta, output_hmm):
             command = [
                 "hmmbuild",
                 "--cpu",
-                str(cpu_count()),
+                str(len(sched_getaffinity(0))),
                 "-n",
                 hmm_name,
                 "-o",

--- a/misc/assign_gtdb_taxonomy/fetch_taxonomy_from_api.py
+++ b/misc/assign_gtdb_taxonomy/fetch_taxonomy_from_api.py
@@ -10,15 +10,13 @@ import argparse
 
 def fetch_pool(num_threads: int):
     num_cpus = len(sched_getaffinity(0))
-    if num_threads > num_cpus:
-        print("There were more threads ({}) requested than CPUs available ({}), setting num_threads to {}\n".format(num_threads, num_cpus, num_cpus))
-        num_threads = num_cpus
+    available_cpu_ids = list(sched_getaffinity(0))
     pool = Pool(processes=num_threads)
     try:
         # set cores for the multiprocessing pools
         all_cpu_ids = set()
         for i, p in enumerate(pool._pool):
-            cpu_id = str(list(sched_getaffinity(0))[i])
+            cpu_id = str(available_cpu_ids[len(available_cpu_ids) - (i % len(available_cpu_ids)) - 1)]
             subprocess.run(["taskset",
                             "-p", "-c",
                             cpu_id,
@@ -34,7 +32,6 @@ def fetch_pool(num_threads: int):
     except FileNotFoundError:
         pass  # running in OSX?
     return pool
-
 
 def fetch_taxonomy(results, ncbi_acc, gtdb_version):
     with urllib.request.urlopen(

--- a/misc/assign_gtdb_taxonomy/fetch_taxonomy_from_api.py
+++ b/misc/assign_gtdb_taxonomy/fetch_taxonomy_from_api.py
@@ -9,7 +9,6 @@ import argparse
 
 
 def fetch_pool(num_threads: int):
-    num_cpus = len(sched_getaffinity(0))
     available_cpu_ids = list(sched_getaffinity(0))
     pool = Pool(processes=num_threads)
     try:

--- a/misc/assign_gtdb_taxonomy/fetch_taxonomy_from_api.py
+++ b/misc/assign_gtdb_taxonomy/fetch_taxonomy_from_api.py
@@ -15,7 +15,7 @@ def fetch_pool(num_threads: int):
         # set cores for the multiprocessing pools
         all_cpu_ids = set()
         for i, p in enumerate(pool._pool):
-            cpu_id = str(available_cpu_ids[len(available_cpu_ids) - (i % len(available_cpu_ids)) - 1)]
+            cpu_id = str(available_cpu_ids[len(available_cpu_ids) - (i % len(available_cpu_ids)) - 1])
             subprocess.run(["taskset",
                             "-p", "-c",
                             cpu_id,


### PR DESCRIPTION
On a multi-user cluster with cgroups enforcing CPU affinity, the taskset lines fail, as cores not assigned to the job may be selected.
This gets the set of cores assigned, and only assigns cores in that set.
In addition as not all cores are guaranteed to be available (especially on a shared-use cluster), this counts the number of available cores, and passes that as `--cpu` as appropriate.

In my testing, this continues to work on a single-user system (without any cgroups constraining things).