### PR TITLE
Bugfix: Explicitly use "amino" alphabet when reading in CDS multifasta

### DIFF
--- a/bigslice/bigslice
+++ b/bigslice/bigslice
@@ -1345,7 +1345,7 @@ def main():
 
                     in_fasta_path = fasta_path(chunk_name)
 
-                    sequences = list(easel.SequenceFile(in_fasta_path, digital=True))
+                    sequences = list(easel.SequenceFile(in_fasta_path, digital=True, alphabet=easel.Alphabet.amino()))
                     with plan7.HMMFile(hmm_path) as hmm_file:
                         for top_hits in hmmer.hmmsearch(
                             hmm_file, sequences,


### PR DESCRIPTION
This PR fixes #82, which can be caused by the `pyhmmer.easel` module not being able to guess the alphabet of a `SequenceFile` (i.e. `easel.dna()`, `easel.rna()`, or `easel.amino()` from the first sequence alone. In my case, it was due to the first CDS in the multifasta being very short (`MHILN`, 5 residues).

Since BiG-SLiCE's CDS multifastas are all protein sequences, explicitly using the `amino()` alphabet when calling `easel.SequenceFile()` fixes the issue.