### PR TITLE
Use sqlite3 builtin database `backup()` to avoid query string size limit

### DIFF
--- a/bigslice/modules/data/database.py
+++ b/bigslice/modules/data/database.py
@@ -158,8 +158,7 @@ class Database:
             if path.exists(self._db_path):
                 move(self._db_path, self._db_path + ".bak")
             with sqlite3.connect(self._db_path) as out_db:
-                query = "".join([line for line in self._connection.iterdump()])
-                out_db.executescript(query)
+                self._connection.backup(out_db)
             print("{0:.4f}s".format(time() - start))
         else:
             raise(Exception("not an in-memory database"))


### PR DESCRIPTION
Dumping SQL from large runs can cause the `qeury` string to exceed the size limit, causing the run to fail. Recent versions of the `sqlite3` module (since v3.7) have a builtin `backup()` method for this that does not run into this problem.

This PR contains the small change to BiG-SLiCE's `database` module to use this `backup()` function.