### PR TITLE
Update code to support latest versions of pyhmmer and scikit-learn

### DIFF
--- a/bigslice/bigslice
+++ b/bigslice/bigslice
@@ -55,8 +55,8 @@ def run_subpfam_scan(tuples):
             for hit in top_hits:
                 if hit.best_domain.score < top_hits.domT:
                     continue
-                target_name = hit.name.decode()
-                hmm_name = top_hits.query_name.decode()
+                target_name = hit.name
+                hmm_name = top_hits.query.name
                 alignment = hit.best_domain.alignment
 
                 bgc_id, cds_id, parent_hsp_id, locs = target_name.split("|")
@@ -102,8 +102,8 @@ def run_subpfam_scan_hmmscan(tuples):
                     # this will return a sorted high-to-low hits, so no need to re-sort
                     if i >= top_k:
                         break
-                    target_name = sequence.name.decode()
-                    hmm_name = hit.name.decode()
+                    target_name = sequence.name
+                    hmm_name = hit.name
 
                     bgc_id, cds_id, parent_hsp_id, locs = target_name.split("|")
                     bgc_id = int(bgc_id.split("bgc:")[-1])
@@ -673,8 +673,8 @@ def query_mode(report_name, input_folder, input_run_id, pool,
                             if hit.best_domain.score < top_hits.domT:
                                 continue
 
-                            target_name = hit.name.decode()
-                            hmm_name = top_hits.query_accession.decode()
+                            target_name = hit.name
+                            hmm_name = top_hits.query.accession
                             alignment = hit.best_domain.alignment
 
                             bgc_id, cds_id, parent_hsp_id, locs = target_name.split("|")
@@ -1365,8 +1365,8 @@ def main():
                                 if hit.best_domain.score < top_hits.domT:
                                     continue
 
-                                target_name = hit.name.decode()
-                                hmm_name = top_hits.query_accession.decode()
+                                target_name = hit.name
+                                hmm_name = top_hits.query.accession
                                 alignment = hit.best_domain.alignment
 
                                 bgc_id, cds_id, parent_hsp_id, locs = target_name.split("|")
@@ -1648,8 +1648,8 @@ def main():
                                         cpus=args.num_threads, T=20
                                         ):
                                         for hit in top_hits:
-                                            target_name = hit.name.decode()
-                                            hmm_name = top_hits.query_name.decode()
+                                            target_name = hit.name
+                                            hmm_name = top_hits.query.name
                                             alignment = hit.best_domain.alignment
 
                                             bgc_id, cds_id, parent_hsp_id, locs = target_name.split("|")

--- a/bigslice/modules/clustering/birch.py
+++ b/bigslice/modules/clustering/birch.py
@@ -185,8 +185,7 @@ class BirchClustering:
         # initiate birch object
         birch = Birch(
             n_clusters=None,  # no global clustering
-            compute_labels=False,  # only calc centroids
-            copy=False  # data already copied
+            compute_labels=False  # only calc centroids
         )
 
         # set threshold


### PR DESCRIPTION
Versions are not documented clearly for the libraries needed, as such things break in latest versions of the pip install and docker releases. I fixed the issues and the bigslice test case at least seams to work now with scikit-learn 1.8.0 and pyhmmer 0.12.0

scikit-learn: Starting from version 1.3.0, copy is no longer a valid parameter in Birch clustering of scikit learn.
pyhmmer: This property replaces the query_name, query_accession and query_length properties that were deprecated in *v0.10.15* and removed in *v0.11.0*. From 0.11 onwards you have to access the name, accession and length as a property of the query object.